### PR TITLE
EN-1946: Update ticker tape with latest library

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import com.typesafe.sbt.packager.docker._
 lazy val commonSettings = Seq(
   organization := "com.socrata",
   version := "0.1.0",
-  scalaVersion := "2.10.5",
+  scalaVersion := "2.11.7",
   libraryDependencies ++= Seq(
     scala_logging,
     slf4j_log4j,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,7 +24,7 @@ object Dependencies {
     val log4j = "log4j" % "log4j" % versions.log4j
 
     val typesafe_config = "com.typesafe" % "config" % versions.typesafe_config
-    val balboa_client = "com.socrata" %% "balboa-client-core" % versions.balboa_client
+    val balboa_client = "com.socrata" %% "balboa-client" % versions.balboa_client
     val jopt_simple = "net.sf.jopt-simple" % "jopt-simple" % versions.jopt_simple
     val joda_convert = "org.joda" % "joda-convert" % versions.joda_convert
     val joda_time = "joda-time" % "joda-time" % versions.joda_time
@@ -32,7 +32,7 @@ object Dependencies {
 
   object Resolvers {
 
-    val socrata_release = "socrata maven" at "https://repository-socrata-oss.forge.cloudbees.com/release"
+    val socrata_release = "socrata maven" at "https://repo.socrata.com/artifactory/libs-release-local"
 
   }
 


### PR DESCRIPTION
Ticker tape serves as the best example of how to use balboa MetricFileQueue.
This updates the example to use the latest library.
