### PR TITLE
EN-2590 Allow Intellij to correctly import project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,10 +23,10 @@ lazy val commonSettings = Seq(
   JavaFindBugsPlugin.JavaFindBugsKeys.findbugsFailOnError in Test := false
 )
 
-lazy val tickerTape = (project in file(".")).
+lazy val `ticker-tape` = (project in file(".")).
   settings(commonSettings: _*).
   settings(
-    name := "tickerTape",
+    name := "ticker-tape",
     resolvers += socrata_release,
     libraryDependencies ++= Seq(balboa_client, balboa_client_jms)
   ).enablePlugins(JavaAppPackaging).


### PR DESCRIPTION
When Intellij imports a project, it seems to detect the names of the
modules in at least two places. One in the build.sbt file and one from
the directory name. Originally the two places had different names
('ticker-tape' for the directory and 'tickerTape' for things in the
build.sbt file). During importing the project, Intellij would detect the
two names and create extra modules. Dependencies wouldn't import and
there would be red everywhere.
